### PR TITLE
🐛 Fix console message measurement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,19 +19,19 @@ repos:
       - id: isort
         stages: [commit]
 
-  - repo: https://ghproxy.com/github.com/psf/black
+  - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:
       - id: black
         stages: [commit]
 
-  - repo: https://ghproxy.com/github.com/pre-commit/mirrors-prettier
+  - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.0-alpha.9-for-vscode
     hooks:
       - id: prettier
         stages: [commit]
 
-  - repo: https://ghproxy.com/github.com/nonebot/nonemoji
+  - repo: https://github.com/nonebot/nonemoji
     rev: v0.1.4
     hooks:
       - id: nonemoji

--- a/nonechat/message.py
+++ b/nonechat/message.py
@@ -145,9 +145,7 @@ class ConsoleMessage(Sequence[Element]):
     def __rich_measure__(
         self, console: "Console", options: "ConsoleOptions"
     ) -> Measurement:
-        measurements = [
-            measure_renderables(console, options, (element,)) for element in self
-        ]
+        measurements = [Measurement.get(console, options, element) for element in self]
         return Measurement(
             sum(i.minimum for i in measurements), sum(i.maximum for i in measurements)
         )

--- a/nonechat/message.py
+++ b/nonechat/message.py
@@ -145,7 +145,12 @@ class ConsoleMessage(Sequence[Element]):
     def __rich_measure__(
         self, console: "Console", options: "ConsoleOptions"
     ) -> Measurement:
-        return measure_renderables(console, options, self)
+        measurements = [
+            measure_renderables(console, options, (element,)) for element in self
+        ]
+        return Measurement(
+            sum(i.minimum for i in measurements), sum(i.maximum for i in measurements)
+        )
 
     def __str__(self):
         return "".join(map(str, self.content))


### PR DESCRIPTION
## Changes

修复多段消息长度的测量，`measure_renderables` 返回的是可以容纳序列中任一元素的长度范围，对于消息序列应对每个元素的上下限取和。

同时移除了已失效的 ghproxy.com 代理。

## Problem

在 `ConsoleMessage` 中存在多个消息段时，计算得到的最大显示宽度不正确，在修改后的 `main.py` 测试代码中：

```diff
@@ -80,7 +80,7 @@ async def send_message(message: ConsoleMessage):
 @app.backend.register()
 async def on_message(event: MessageEvent):
     if str(event.message) == "ping":
-        await send_message(ConsoleMessage([Text("pong!")]))
+        await send_message(ConsoleMessage([Text("pong1"), Text("pong2")]))
 
 
 app.run()
```

回复对话框中只能显示 `pong1`，而 `pong2` 没有足够的长度显示。

## Solution

不使用取长度上下限的 `measure_renderables` 函数，计算每个元素的长度范围对上下限进行求和。定义参考：

https://github.com/Textualize/rich/blob/v13.4.2/rich/measure.py#L125-L151
https://github.com/Textualize/rich/blob/v13.4.2/rich/measure.py#L78-L94
